### PR TITLE
fix: add text.jade to scope of Jade icon and new line to Elixir

### DIFF
--- a/Prefs/icon_elixir.tmPreferences
+++ b/Prefs/icon_elixir.tmPreferences
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist
+  PUBLIC '-//Apple//DTD PLIST 1.0//EN'
+  'http://www.apple.com/DTDs/PropertyList-1.0.dtd'>
 <plist version="1.0">
-    <dict>
-        <key>scope</key>
-        <string>source.elixir</string>
-        <key>settings</key>
-        <dict>
-            <key>icon</key>
-            <string>file_type_ex</string>
-        </dict>
-    </dict>
+	<dict>
+		<key>scope</key>
+		<string>source.elixir</string>
+		<key>settings</key>
+		<dict>
+			<key>icon</key>
+			<string>file_type_ex</string>
+		</dict>
+	</dict>
 </plist>

--- a/Prefs/icon_jade.tmPreferences
+++ b/Prefs/icon_jade.tmPreferences
@@ -5,7 +5,7 @@
 <plist version="1.0">
     <dict>
         <key>scope</key>
-        <string>source.jade</string>
+        <string>source.jade, text.jade</string>
         <key>settings</key>
         <dict>
             <key>icon</key>


### PR DESCRIPTION
Jade icon was showing as a text file instead of a Jade file:

Before:
![screen shot 2016-04-19 at 8 06 59 pm](https://cloud.githubusercontent.com/assets/1154799/14659558/13112918-066b-11e6-940d-c3d9bcfb696c.png)

After:
![screen shot 2016-04-19 at 8 07 16 pm](https://cloud.githubusercontent.com/assets/1154799/14659577/1fa283c0-066b-11e6-9129-b2fce3f26197.png)
