### PR TITLE
Experimental Light theme

### DIFF
--- a/Alpenglow-light.sublime-theme
+++ b/Alpenglow-light.sublime-theme
@@ -1,0 +1,1129 @@
+[
+    //  TABS
+    //  ==========================================================
+    //  - Tabset
+    //  ------------------------------------------------------
+    {
+        "class": "tabset_control",
+        // "layer0.texture": "Theme - Alpenglow/Alpenglow/tab-background.png",
+        "layer0.tint": [190, 190, 180], // -00
+        "layer0.inner_margin": 0,
+        "layer0.opacity": 1,
+        "content_margin": [0, 0, 0, 8],
+        "tab_overlap": 0,
+        "tab_width": 128,
+        "tab_min_width": 48,
+        "tab_height": 65,
+        "mouse_wheel_switch": false
+    },
+    {
+        "class": "tabset_control",
+        "settings": ["mouse_wheel_switches_tabs"],
+        "mouse_wheel_switch": true
+    },
+    {
+        "class": "tabset_control",
+        "settings": ["tabs_small"],
+        // "layer0.texture": "Theme - Alpenglow/Alpenglow/tab-background-small.png",
+        "layer0.tint": [190, 190, 180],
+        "tab_height": 30
+    },
+    {
+        "class": "tabset_control",
+        "settings": ["tabs_medium"],
+        // "layer0.texture": "Theme - Alpenglow/Alpenglow/tab-background-medium.png",
+        "layer0.tint": [190, 190, 180],
+        "tab_height": 45
+    },
+
+    //  - Tab element
+    //  ------------------------------------------------------
+    {
+        "class": "tab_control",
+        "content_margin": [22, 0, 22, 0],
+        "max_margin_trim": 0,
+        "hit_test_level": 0,
+
+        //  - Inactive tab settings
+        // "layer0.texture": "Theme - Alpenglow/Alpenglow/tab-inactive.png",
+        "layer0.tint": [170, 170, 160],
+        "layer0.inner_margin": [0,0],
+        "layer0.opacity": 1.0,
+
+        //  - Active tab setting
+        // "layer1.texture": "Theme - Alpenglow/Alpenglow/tab-active.png",
+        "layer1.tint": [190, 190, 180],
+        "layer1.inner_margin": [0,0],
+        "layer1.opacity": 0.0,
+
+        //  - Hover tab setting
+        // "layer2.texture": "Theme - Alpenglow/Alpenglow/tab-hover.png",
+        "layer2.tint": [190, 190, 180],
+        "layer2.inner_margin": [0,0],
+        "layer2.opacity": 0.0
+    },
+    {
+        //  - Tab close state
+        "class": "tab_control",
+        "settings": ["show_tab_close_buttons"],
+        "content_margin": [22, 0, 22, 0]
+    },
+    {
+        //  - Tab close state padding medium
+        "class": "tab_control",
+        "settings": ["tabs_padding_medium"],
+        "content_margin": [16, 0, 12, 0]
+    },
+    {
+        //  - Tab close state padding small
+        "class": "tab_control",
+        "settings": ["tabs_padding_small"],
+        "content_margin": [8, 0, 5, 0]
+    },
+    {
+        //  - Hover tab state
+        "class": "tab_control",
+        "attributes": ["hover"],
+        "layer2.opacity": 1.0
+    },
+    {
+        //  - Active tab state
+        "class": "tab_control",
+        "attributes": ["selected"],
+        "layer0.opacity": 0.0,
+        "layer1.opacity": 1.0,
+        "layer2.opacity": 0.0
+    },
+    {
+        //  - Modified tab state
+        "class": "tab_control",
+        "attributes": ["dirty"],
+        // "layer0.texture": "Theme - Alpenglow/Alpenglow/tab-inactive-modified.png",
+        // "layer1.texture": "Theme - Alpenglow/Alpenglow/tab-active-modified.png",
+        // "layer2.texture": "Theme - Alpenglow/Alpenglow/tab-hover-dirty.png"
+    },
+    {
+        //  - Modified tab state
+        "class": "tab_control",
+        "attributes": ["dirty"],
+        "settings": ["tabs_medium"],
+        // "layer0.texture": "Theme - Alpenglow/Alpenglow/tab-inactive-modified-medium.png",
+        // "layer1.texture": "Theme - Alpenglow/Alpenglow/tab-active-modified-medium.png",
+        // "layer2.texture": "Theme - Alpenglow/Alpenglow/tab-hover-dirty-medium.png"
+    },
+    {
+        //  - Modified tab state
+        "class": "tab_control",
+        "attributes": ["dirty"],
+        "settings": ["tabs_small"],
+        // "layer0.texture": "Theme - Alpenglow/Alpenglow/tab-inactive-modified-small.png",
+        // "layer1.texture": "Theme - Alpenglow/Alpenglow/tab-active-modified-small.png",
+        // "layer2.texture": "Theme - Alpenglow/Alpenglow/tab-hover-dirty-small.png"
+    },
+
+    //  - Tab labels
+    //  ------------------------------------------------------
+
+    //  - Inactive tab label
+    {
+        "class": "tab_label",
+        "fg": [80, 80, 80], // 03
+        "shadow_color": [0, 0, 0, 200],
+        "shadow_offset": [0, 1]
+    },
+
+    //  - Color inactive tab
+    {
+        "class": "tab_label",
+        "settings": ["color_inactive_tabs"],
+        "fg": [229, 181, 103] // 03
+    },
+
+    //  - Active tab label
+    {
+        "class": "tab_label",
+        "parents": [{"class": "tab_control", "attributes": ["selected"]}],
+        "fg": [32, 32, 32]
+    },
+
+    //  - Hover tab label
+    {
+        "class": "tab_label",
+        "parents": [{"class": "tab_control", "attributes": ["hover"]}],
+        "fg": [0, 0, 0]
+    },
+
+    //  - Dirty Hover tab label
+    {
+        "class": "tab_label",
+        "parents": [{"class": "tab_control", "attributes": ["hover", "dirty"]}],
+        "fg": [204, 119, 50]
+    },
+
+    // - Dirty inactive tab label
+    {
+        "class": "tab_label",
+        "parents": [{"class": "tab_control", "attributes": ["dirty"]}],
+        "settings": ["highlight_modified_tabs"]
+    },
+
+    // - Dirty active tab label
+    {
+        "class": "tab_label",
+        "parents": [{"class": "tab_control", "attributes": ["selected", "dirty"]}],
+        "settings": ["highlight_modified_tabs"]
+    },
+
+    // - Preview tab
+    {
+        "class": "tab_label",
+        "attributes": ["transient"],
+        "font.italic": true
+    },
+    {
+        "class": "tab_label",
+        "settings": ["tabs_label_not_italic"],
+        "font.italic": false
+    },
+
+// TAB BUTTONS
+//
+
+    // Tab close button
+    {
+        "class": "tab_close_button",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/close.png",
+        "layer0.opacity": 0,
+        "layer0.tint": [32, 32, 32] // 03
+    },
+    {
+        "class": "tab_close_button",
+        "settings": ["show_tab_close_buttons"],
+        "content_margin": [8,8]
+    },
+    {
+        "class": "tab_close_button",
+        "parents": [{"class": "tab_control","attributes": ["hover"]}],
+        // "layer0.texture": "Theme - Alpenglow/Alpenglow/close.png",
+        "layer0.opacity": 1
+    },
+    {
+        "class": "tab_close_button",
+        "parents": [{"class": "tab_control"}],
+        "attributes": ["hover"],
+        "layer0.opacity": 1,
+        "layer0.tint": [204, 119, 50] // 08
+    },
+    {
+        "class": "tab_close_button",
+        "parents": [{"class": "tab_control","attributes": ["selected"]}],
+        "layer0.opacity": 1
+    },
+    // Tab highlight button
+    {
+        "class": "tab_close_button",
+        "settings": ["highlight_modified_tabs"],
+        "parents": [{"class": "tab_control","attributes": ["dirty"]}]
+    },
+    {
+        "class": "tab_close_button",
+        "settings": ["highlight_modified_tabs"],
+        "parents": [{"class": "tab_control","attributes": ["dirty","selected"]}]
+    },
+    // Tab close button hover
+    {
+        "class": "tab_close_button",
+        "settings": ["show_tab_close_buttons"],
+        "attributes": ["hover"]
+    },
+    // Tab close button pressed
+    {
+        "class": "tab_close_button",
+        "settings": ["show_tab_close_buttons"],
+        "attributes": ["pressed"],
+        "layer0.opacity": 0.5
+    },
+
+//
+// FOLD BUTTONS
+//
+
+    {
+        "class": "fold_button_control",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/arrow-closed.png",
+        "layer0.tint": [32, 32, 32], // 04
+        "layer0.opacity": 0.5,
+        "layer0.inner_margin": 0,
+        "content_margin": [8,8]
+    },
+    {
+        "class": "fold_button_control",
+        "attributes": ["hover"],
+        "layer0.opacity": 0.7
+    },
+    {
+        "class": "fold_button_control",
+        "attributes": ["expanded"],
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/arrow-open.png"
+    },
+    {
+        "class": "fold_button_control",
+        "attributes": ["expanded","hover"]
+    },
+
+//
+// STANDARD SCROLLBARS
+//
+
+    // Standard vertical scroll bar
+    {
+        "class": "scroll_bar_control",
+        "layer0.texture": "",
+        "layer0.tint": [170, 170, 160], // -01
+        "layer0.opacity": 1,
+        "layer0.inner_margin": [0,0],
+        "blur": true
+    },
+    // Standard horizontal scroll bar
+    {
+        "class": "scroll_bar_control",
+        "attributes": ["horizontal"],
+        "layer0.texture": "",
+        "layer0.tint": [170, 170, 160], // -01
+        "layer0.inner_margin": [0,0],
+        "blur": true
+    },
+    // Standard scroll bar corner
+    {
+        "class": "scroll_corner_control",
+        "layer0.texture": "",
+        "layer0.tint": [170, 170, 160], // -01
+        "layer0.inner_margin": [0,0],
+        "layer0.opacity": 1
+    },
+    // Standard vertical scroll puck
+    {
+        "class": "puck_control",
+        "layer0.texture": "",
+        "layer0.tint": [130, 130, 130],
+        "layer0.opacity": 1,
+        "layer0.inner_margin": [0,0],
+        "content_margin": [6,0],
+        "blur": false
+    },
+    // Standard horizontal scroll puck
+    {
+        "class": "puck_control",
+        "attributes": ["horizontal"],
+        "layer0.tint": [127, 127, 127], // 01
+        "layer0.inner_margin": [0,0],
+        "content_margin": [12,6],
+        "blur": false
+    },
+
+//
+// OVERLAY SCROLLBARS
+//
+
+    // Overlay toggle scroll bar
+    {
+        "class": "scroll_area_control",
+        "settings": ["overlay_scroll_bars"],
+        "overlay": true
+    },
+    {
+        "class": "scroll_area_control",
+        "settings": ["!overlay_scroll_bars"],
+        "overlay": false
+    },
+    // Overlay vertical scroll bar
+    {
+        "class": "scroll_bar_control",
+        "settings": ["overlay_scroll_bars"],
+        "layer0.tint": [45, 45, 45], // 00
+        "layer0.inner_margin": [0,5],
+        "layer0.opacity": 0,
+        "blur": false
+    },
+    // Overlay horizontal scroll bar
+    {
+        "class": "scroll_bar_control",
+        "settings": ["overlay_scroll_bars"],
+        "attributes": ["horizontal"],
+        "layer0.inner_margin": [5,0],
+        "layer0.opacity": 0,
+        "blur": true
+    },
+    // Overlay vertical puck
+    {
+        "class": "puck_control",
+        "settings": ["overlay_scroll_bars"],
+        "layer0.texture": "",
+        "layer0.inner_margin": [0,5],
+        "content_margin": [2,32],
+        "blur": true
+    },
+    // Overlay horizontal puck
+    {
+        "class": "puck_control",
+        "settings": ["overlay_scroll_bars"],
+        "attributes": ["horizontal"],
+        "layer0.texture": "",
+        "layer0.inner_margin": [5,0],
+        "content_margin": [16,2],
+        "blur": true
+    },
+    // Overlay light puck (for dark content)
+    {
+        "class": "puck_control",
+        "settings": ["overlay_scroll_bars"],
+        "attributes": ["dark"],
+        "layer0.tint": [81, 81, 81] // 02
+
+    },
+    // Overlay light horizontal puck (for dark content)
+    {
+        "class": "puck_control",
+        "settings": ["overlay_scroll_bars"],
+        "attributes": ["horizontal","dark"],
+        "layer0.tint": [81, 81, 81] // 02
+    },
+
+//
+// EMPTY WINDOW BACKGROUND
+//
+
+    {
+        "class": "sheet_container_control",
+        "layer0.tint": [190, 190, 180],
+        "layer0.opacity": 1
+    },
+
+//
+// GRID LAYOUT
+//
+
+    {
+        "class": "grid_layout_control",
+        "border_size": 1,
+        "border_color": [150, 150, 140] // -00
+    },
+
+//
+// MINI MAP
+//
+
+    {
+        "class": "minimap_control",
+        "viewport_color": [32, 32, 32, 35]
+    },
+
+//
+// LABELS
+//
+
+    // General labels
+    {
+        "class": "label_control",
+        "color": [32, 32, 32] // 0C
+    },
+    // Text field labels
+    {
+        "class": "label_control",
+        "parents": [{"class": "panel_control"}]
+    },
+    // Button labels
+    {
+        "class": "label_control",
+        "parents": [{"class": "button_control"}],
+        "font.bold": true,
+        "color": [32, 32, 32] // 0C
+    },
+
+//
+// TOOLTIP
+//
+
+    // Tooltip container
+    {
+        "class": "tool_tip_control",
+        "layer0.tint": [170, 170, 160], // 02
+        "layer0.inner_margin": [1,1],
+        "layer0.opacity": 1,
+        "content_margin": [10, 8, 10, 8]
+    },
+    // Tooltip content
+    {
+        "class": "tool_tip_label_control",
+        "color": [242, 242, 242] // 07
+    },
+
+//
+// STATUS BAR
+//
+
+    // Status bar container
+    {
+        "class": "status_bar",
+        "layer0.texture": "",
+        "layer0.tint": [170, 170, 160], // -00
+        "layer0.opacity": 1,
+        "content_margin": 4
+    },
+    // Status bar button
+    {
+        "class": "status_button",
+        "min_size": [92, 0]
+    },
+    // Status bar label
+    {
+        "class": "label_control",
+        "parents": [{"class": "status_bar"}],
+        "color": [60, 60, 60] // 02
+    },
+    // Status bar label brighter
+    {
+        "class": "label_control",
+        "parents": [{"class": "status_bar"}],
+        "settings": ["status_bar_brighter"],
+        "color": [32, 32, 32]
+    },
+
+//
+// SIDEBAR
+//
+
+    // Sidebar container
+    {
+        "class": "sidebar_container",
+        "layer0.opacity": 1,
+        "layer0.tint": [190, 190, 180], // -01
+        "layer0.inner_margin": [1,5,2,1],
+        "content_margin": [0,4,0,0]
+    },
+    // Sidebar tree
+    {
+        "class": "sidebar_tree",
+        "row_padding": [8,4],
+        "indent": 16,
+        "indent_offset": 16,
+        "indent_top_level": false,
+        "dark_content": true
+    },
+    // Sidebar tree padding medium
+    {
+        "class": "sidebar_tree",
+        "settings": ["sidebar_row_padding_medium"],
+        "row_padding": [8,5],
+        "indent": 16,
+        "indent_offset": 16,
+        "indent_top_level": false,
+        "dark_content": true
+    },
+    // Sidebar tree padding large
+    {
+        "class": "sidebar_tree",
+        "settings": ["sidebar_row_padding_large"],
+        "row_padding": [8,6],
+        "indent": 16,
+        "indent_offset": 16,
+        "indent_top_level": false,
+        "dark_content": true
+    },
+    // Sidebar rows
+    {
+        "class": "tree_row",
+        // "layer0.texture": "",
+        "layer0.tint": [204, 119, 50], // 01
+        "layer0.opacity": 0,
+        "layer0.inner_margin": [1,1]
+    },
+    // Sidebar row selected
+    {
+        "class": "tree_row",
+        "attributes": ["selected"],
+        "layer0.opacity": 1
+
+    },
+    // Sidebar heading
+    {
+        "class": "sidebar_heading",
+        "color": [204, 119, 50], // 03
+        // "color": [229, 181, 103], // 03
+        "font.bold": true
+    },
+    // Sidebar heading selected
+    {
+        "class": "sidebar_heading",
+        "parents": [{"class": "tree_row","attributes": ["selected"]}],
+        "shadow_offset": [0,0]
+    },
+    // Sidebar entry
+    {
+        "class": "sidebar_label",
+        // "font.size": 13,
+        "color": [32, 32, 32] // 03
+    },
+    // Sidebar entry font size 12
+    {
+        "class": "sidebar_label",
+        "settings": ["sidebar_size_12"],
+        "font.size": 12,
+        "color": [32, 32, 32] // 03
+    },
+    // Sidebar entry font size 13
+    {
+        "class": "sidebar_label",
+        "settings": ["sidebar_size_13"],
+        "font.size": 13,
+        "color": [32, 32, 32] // 03
+    },
+    // Sidebar entry font size 14
+    {
+        "class": "sidebar_label",
+        "settings": ["sidebar_size_14"],
+        "font.size": 14,
+        "color": [32, 32, 32] // 03
+    },
+    // Sidebar folder entry
+    {
+        "class": "sidebar_label",
+        "parents": [{"class": "tree_row","attributes": ["expandable"]}],
+        // "font.bold": true,
+        "color": [64, 64, 64] // 03
+    },
+    {
+        "class": "sidebar_label",
+        "parents": [{"class": "tree_row","attributes": ["hover"]}],
+        "color": [0, 0, 0] // 05
+    },
+    {
+        "class": "sidebar_label",
+        "parents": [{"class": "tree_row","attributes": ["expandable"]}],
+        "settings": ["bold_folder_labels"],
+        "font.bold": true
+    },
+    // Sidebar entry selected
+    {
+        "class": "sidebar_label",
+        "parents": [{"class": "tree_row","attributes": ["selected"]}],
+        "color": [232, 232, 232] // 06
+    },
+
+//
+// SIDEBAR - OPEN FILE ICONS
+//
+
+    // Sidebar file close
+    {
+        "class": "close_button",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/close.png",
+        "layer0.opacity": 0,
+        "layer0.inner_margin": 0,
+        "layer0.tint": [81, 81, 81], // 02
+        "content_margin": [8,8]
+    },
+    {
+        "class": "close_button",
+        "parents": [{"class": "tree_row","attributes": ["selected"]}],
+        "layer0.opacity": 1
+    },
+    {
+        "class": "close_button",
+        "parents": [{"class": "tree_row","attributes": ["hover"]}],
+        "layer0.opacity": 1
+    },
+    // Sidebar file dirty
+    {
+        "class": "close_button",
+        "attributes": ["dirty"],
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/modified.png",
+        "layer0.opacity": 1,
+        "layer0.tint": [204, 119, 50] // 0A
+    },
+    {
+        "class": "close_button",
+        "attributes": ["dirty"],
+        "parents": [{"class": "tree_row","attributes": ["selected"]}],
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/modified.png"
+    },
+    // Sidebar file close hover
+    {
+        "class": "close_button",
+        "attributes": ["hover"],
+        "layer0.tint": [229, 181, 103] // 08
+    },
+    {
+        "class": "close_button",
+        "attributes": ["dirty", "hover"],
+        "parents": [{"class": "tree_row","attributes": ["hover"]}],
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/close.png",
+        "layer0.tint": [229, 181, 103] // 08
+    },
+
+//
+// SIDEBAR - GENERAL FILE ICONS
+//
+
+    // Sidebar group closed
+    {
+        "class": "disclosure_button_control",
+        "content_margin": [8,8],
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/folder-closed.png",
+        "layer0.tint": [64, 64, 64], // 02
+        "layer0.opacity": 1,
+        "layer0.inner_margin": 0
+    },
+    {
+        "class": "disclosure_button_control",
+        "parents": [{"class": "tree_row","attributes": ["hover"]}],
+        "layer0.tint": [0, 0, 0] // 04
+    },
+    {
+        "class": "disclosure_button_control",
+        "parents": [{"class": "tree_row","attributes": ["selected"]}]
+    },
+    // Sidebar group open
+    {
+        "class": "disclosure_button_control",
+        "attributes": ["expanded"],
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/folder-open.png"
+    },
+    {
+        "class": "disclosure_button_control",
+        "attributes": ["expanded"],
+        "parents": [{"class": "tree_row","attributes": ["hover"]}]
+    },
+    {
+        "class": "disclosure_button_control",
+        "attributes": ["expanded"],
+        "parents": [{"class": "tree_row","attributes": ["selected"]}],
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/folder-open.png"
+    },
+    // Icons sidebar
+    {
+        "class": "icon_folder",
+        "content_margin": [8,8],
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/folder-closed-folder.png",
+        "layer0.tint": [204, 119, 50, 200] // 08
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [8,8],
+        "parents": [{"class": "tree_row","attributes": ["hover"]}],
+        "layer0.tint": [204, 119, 50, 255] // 08
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [8,8],
+        "parents": [{"class": "tree_row","attributes": ["expanded"]}],
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/folder-open-folder.png"
+    },
+    {
+        "class": "icon_folder",
+        "settings": ["folder_no_icon"],
+        "content_margin": [0, 0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_file_type",
+        "layer0.opacity": 0.85,
+        "content_margin": [8, 8]
+    },
+    {
+        "class": "icon_file_type",
+        "settings": ["sidebar_no_icon"],
+        "content_margin": [0, 0]
+    },
+    {
+        "class": "icon_file_type",
+        "parents": [{"class": "tree_row", "attributes": ["hover"]}],
+        "layer0.opacity": 1.0
+    },
+    {
+        "class": "icon_file_type",
+        "parents": [{"class": "tree_row", "attributes": ["selected"]}],
+        "layer0.opacity": 1.0
+    },
+
+//
+// STANDARD TEXT BUTTONS
+//
+
+    // Default button state
+    {
+        "class": "button_control",
+        "content_margin": [4,8,4,8],
+        "min_size": [64,0],
+        "layer0.texture": "",
+        "layer0.opacity": 1,
+        "layer0.tint": [170, 170, 160], // -00
+        "layer0.inner_margin": [8,8]
+    },
+    // Hover button state
+    {
+        "class": "button_control",
+        "attributes": ["hover"],
+        "layer0.texture": "",
+        "layer0.tint": [190, 190, 180] // -01
+    },
+    // Pressed button state
+    {
+        "class": "button_control",
+        "attributes": ["pressed"],
+        "layer0.texture": "",
+        "layer0.tint": [150, 150, 140] // -00
+    },
+//
+// TEXT INPUT FIELD
+//
+
+    // Text input field item
+    {
+        "class": "text_line_control",
+        "layer0.texture": "",
+        "layer0.tint": [170, 170, 160], // -01
+        "layer0.opacity": 1,
+        "content_margin": [3, 5, 3, 3]
+    },
+
+//
+// PANEL BACKGROUNDS
+//
+
+    // Bottom panel background
+    {
+        "class": "panel_control",
+        "layer0.texture": "",
+        "layer0.inner_margin": [0,0],
+        "layer0.opacity": 1,
+        "layer0.tint": [170, 170, 160], // -00
+        "content_margin": 0
+    },
+    // Quick panel background
+    {
+        "class": "overlay_control",
+        "layer0.opacity": 1,
+        "layer1.texture": "",
+        "layer1.tint": [170, 170, 160], // 01
+        "layer1.inner_margin": [0,0,0,0],
+        "layer1.opacity": 1,
+        "content_margin": 0
+    },
+
+//
+// QUICK PANEL
+//
+
+    {
+        "class": "quick_panel",
+        "row_padding": 8,
+        "layer0.tint": [170, 170, 160],
+        "layer0.opacity": 1,
+        "dark_content": true
+    },
+    {
+        "class": "quick_panel_row",
+        "layer0.texture": "",
+        "layer0.tint": [170, 170, 160], // 01
+        "layer0.inner_margin": 8,
+        "layer0.opacity": 1
+    },
+    {
+        "class": "quick_panel_row",
+        "attributes": ["selected"],
+        "layer0.texture": "",
+        "layer0.tint": [190, 190, 180] // -01
+    },
+    {
+        "class": "quick_panel_label",
+        "fg": [64, 64, 64, 255], // 04
+        "match_fg": [32, 32, 32, 255], // 05
+        "selected_fg": [32, 32, 32, 255], // 05
+        "selected_match_fg": [0, 0, 0, 255] // 07
+    },
+    {
+        "class": "quick_panel_path_label",
+        "fg": [90, 90, 90, 255], // 03
+        "match_fg": [64, 64, 64, 255], // 04
+        "selected_fg": [64, 64, 64, 255], // 03
+        "selected_match_fg": [64, 64, 64, 255] // 04
+    },
+    {
+        "class": "quick_panel_score_label",
+        "fg": [90, 90, 90, 255], // 03
+        "selected_fg": [64, 64, 64, 255] // 03
+    },
+
+//
+// MINI QUICK PANEL
+//
+
+    {
+        "class": "mini_quick_panel_row",
+        "layer0.texture": "",
+        "layer0.tint": [170, 170, 160], // 01
+        "layer0.opacity": 1
+    },
+    {
+        "class": "mini_quick_panel_row",
+        "attributes": ["selected"],
+        "layer0.texture": "",
+        "layer0.tint": [190, 190, 180] // -01
+    },
+
+//
+// CODE COMPLETION DROPDOWN
+//
+
+    {
+        "class": "popup_control",
+        "content_margin": [0,0],
+        "layer0.tint": [190, 190, 180], // 01
+        "layer0.opacity": 1
+    },
+    {
+        "class": "auto_complete",
+        "row_padding": [4,4]
+    },
+    {
+        "class": "auto_complete_label",
+        "fg": [32, 32, 32, 255], // 03
+        "match_fg": [32, 32, 32, 255], // 05
+        "selected_fg": [32, 32, 32, 255], // 03
+        "selected_match_fg": [32, 32, 32, 255] // 05
+    },
+    {
+        "class": "table_row",
+        "layer0.texture": "",
+        "layer0.tint": [170, 170, 160], // 02
+        "layer0.opacity": 0,
+        "layer0.inner_margin": [3,1]
+    },
+    {
+        "class": "table_row",
+        "attributes": ["selected"],
+        "layer0.opacity": 1
+    },
+
+//
+// BOTTOM PANEL BUTTONS
+//
+
+    // Button group middle
+    {
+        "class": "icon_button_control",
+        "layer1.opacity": 0,
+        "content_margin": 7
+    },
+    {
+        "class": "icon_button_control",
+        "attributes": ["selected"],
+        "layer0.opacity": 0
+    },
+    // Button group left
+    {
+        "class": "icon_button_control",
+        "attributes": ["left"]
+    },
+    // Button group left
+    {
+        "class": "icon_button_control",
+        "attributes": ["left"]
+    },
+    {
+        "class": "icon_button_control",
+        "attributes": ["left","selected"]
+    },
+    // Button group right
+    {
+        "class": "icon_button_control",
+        "attributes": ["right"]
+    },
+    {
+        "class": "icon_button_control",
+        "attributes": ["right","selected"]
+    },
+    // Button single
+    {
+        "class": "icon_button_control",
+        "attributes": ["left","right"]
+    },
+    {
+        "class": "icon_button_control",
+        "attributes": ["left","right","selected"]
+    },
+
+//
+// BOTTOM PANEL ICONS - GROUP 1
+//
+
+    // Regex search button
+    {
+        "class": "icon_regex",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/regex.png",
+        "layer0.tint": [32, 32, 32], // 02
+        "layer0.opacity": 1,
+        "content_margin": 8
+
+    },
+    {
+        "class": "icon_regex",
+        "parents": [{"class": "icon_button_control","attributes": ["selected"]}],
+        "layer0.tint": [204, 119, 50] // 07
+    },
+    // Case sensitive search button
+    {
+        "class": "icon_case",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/casesens.png",
+        "layer0.tint": [32, 32, 32], // 02
+        "layer0.opacity": 1,
+        "content_margin": 8
+    },
+    {
+        "class": "icon_case",
+        "parents": [{"class": "icon_button_control","attributes": ["selected"]}],
+        "layer0.tint": [204, 119, 50] // 07
+    },
+    // Match whole word search button
+    {
+        "class": "icon_whole_word",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/wholeword.png",
+        "layer0.tint": [32, 32, 32], // 02
+        "layer0.opacity": 1,
+        "content_margin": 8
+    },
+    {
+        "class": "icon_whole_word",
+        "parents": [{"class": "icon_button_control","attributes": ["selected"]}],
+        "layer0.tint": [204, 119, 50] // 07
+    },
+
+//
+// BOTTOM PANEL ICONS - GROUP 1 (EXTENDED: FIND IN FILES)
+//
+
+    // Show search context button
+    {
+        "class": "icon_context",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/context.png",
+        "layer0.tint": [32, 32, 32], // 02
+        "layer0.opacity": 1,
+        "content_margin": 8
+    },
+    {
+        "class": "icon_context",
+        "parents": [{"class": "icon_button_control","attributes": ["selected"]}],
+        "layer0.tint": [204, 119, 50] // 07
+    },
+    // Use search buffer
+    {
+        "class": "icon_use_buffer",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/buffer.png",
+        "layer0.tint": [32, 32, 32], // 02
+        "layer0.opacity": 1,
+        "content_margin": 8
+    },
+    {
+        "class": "icon_use_buffer",
+        "parents": [{"class": "icon_button_control","attributes": ["selected"]}],
+        "layer0.tint": [204, 119, 50] // 07
+    },
+
+//
+// BOTTOM PANEL ICONS - GROUP 2
+//
+    // Reverse search direction button (ST2 only)
+    {
+        "class": "icon_reverse",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/reverse.png",
+        "layer0.tint": [32, 32, 32], // 02
+        "layer0.opacity": 1,
+        "content_margin": 8
+    },
+    {
+        "class": "icon_reverse",
+        "parents": [{"class": "icon_button_control","attributes": ["selected"]}],
+        "layer0.tint": [204, 119, 50] // 07
+    },
+    // Search wrap button
+    {
+        "class": "icon_wrap",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/wrap.png",
+        "layer0.tint": [32, 32, 32], // 02
+        "layer0.opacity": 1,
+        "content_margin": 8
+    },
+    {
+        "class": "icon_wrap",
+        "parents": [{"class": "icon_button_control","attributes": ["selected"]}],
+        "layer0.tint": [204, 119, 50] // 07
+    },
+    // Search in selection button
+    {
+        "class": "icon_in_selection",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/selection.png",
+        "layer0.tint": [32, 32, 32], // 02
+        "layer0.opacity": 1,
+        "content_margin": 8
+    },
+    {
+        "class": "icon_in_selection",
+        "parents": [{"class": "icon_button_control","attributes": ["selected"]}],
+        "layer0.tint": [204, 119, 50] // 07
+    },
+
+//
+// BOTTOM PANEL ICONS - GROUP 3
+//
+
+    // Preserve case button
+    {
+        "class": "icon_preserve_case",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/lock.png",
+        "layer0.tint": [32, 32, 32], // 02
+        "layer0.opacity": 1,
+        "content_margin": 8
+    },
+    {
+        "class": "icon_preserve_case",
+        "parents": [{"class": "icon_button_control","attributes": ["selected"]}],
+        "layer0.tint": [204, 119, 50] // 07
+    },
+
+//
+// BOTTOM PANEL ICONS - GROUP 4
+//
+
+    // Highlight results button
+    {
+        "class": "icon_highlight",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/highlight.png",
+        "layer0.tint": [32, 32, 32], // 02
+        "layer0.opacity": 1,
+        "content_margin": 8
+    },
+    {
+        "class": "icon_highlight",
+        "parents": [{"class": "icon_button_control","attributes": ["selected"]}],
+        "layer0.tint": [204, 119, 50] // 07
+    },
+
+// Symlink
+    {
+        "class": "icon_folder_dup",
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/folder_dup.png",
+        "layer0.opacity": 0.6,
+        "content_margin": [8, 8]
+    },
+    {
+        "class": "icon_folder_dup",
+        "parents": [{"class": "tree_row", "attributes": ["hover"]}],
+        "layer0.texture": "Theme - Alpenglow/Alpenglow/folder_dup.png",
+        "layer0.opacity": 1
+    }
+
+]


### PR DESCRIPTION
This is an experimental light theme written by @simonhaenisch
and published originally in
- #17
- http://github.com/AlpenglowTheme/alpenglow-theme/issues/17#issuecomment-220962908
- http://github.com/AlpenglowTheme/alpenglow-theme/files/277426/Alpenglow.Light.zip:

Further TODOs:
- [ ] create tab bar png files (to highlight dirty tabs)
- [ ] set layer textures for tab bar
- [ ] create darkened icons
- [ ] test all elements/theme settings

![screenshot with solarized light scheme](https://cloud.githubusercontent.com/assets/3410759/15470266/eb7905ca-20ef-11e6-8dba-3cc63c7b45c7.PNG)

Personally, I think we can already include this as an experimental feature to gain more traction for this new theme and hopefully attract new ideas of what should happen with the current issues it has.
